### PR TITLE
Set default values everywhere in config example file

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -20,20 +20,20 @@ module.exports = {
       //
       // Beware that the github usernames are case sensitive.
       colorByDev: {
-         "neyric": "ganttBlue",
+         "gh-username": "ganttBlue",
          "unassigned": "ganttRed"
       },
 
       // Configure off periods
       holidays: {
-         "neyric": [
+         "gh-username": [
             { start: "2017-08-08", end: "2017-08-13", title: "Summer holidays"}
          ]
       },
 
       // Exclude milestones listed below from the Gantt Chart
       excludedMilestones: [
-         "Feature Paradize"
+         "Milestone Name"
       ],
 
       // Default duration (in days) for an issue which is not labelled


### PR DESCRIPTION
Sometimes in config.example.js,  _neyric_ is set as github user, and _Feature Paradise_ as Excluded milestones.

In this pull request, I propose to replace 'neyric' by 'gh-username', and 'Feature Paradise' by 'Milestone Name' in config.example.js

Take care ! ;-)

